### PR TITLE
Add `--json` and `--quiet` flags for scripting support

### DIFF
--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -326,8 +326,6 @@ func removeFromClipboard(index int) error {
 	return writeClipboard(clipboard)
 }
 
-// is it better to build this at display time or at cut time?
-// should this just be nesting the clipboard Entry?
 type listEntry struct {
 	index         int
 	basePath      string

--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -84,8 +84,15 @@ func writeClipboard(clipboard Clipboard) error {
 	return err
 }
 
+type Options struct {
+	persist  bool
+	quiet    bool
+	detailed bool
+	json     bool
+}
+
 // cutFile adds a file or directory to the clipboard
-func cutFile(w io.Writer, path string, quiet bool) error {
+func cutFile(w io.Writer, path string, opts Options) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return err
@@ -119,7 +126,7 @@ func cutFile(w io.Writer, path string, quiet bool) error {
 		return err
 	}
 
-	if quiet {
+	if opts.quiet {
 		w = io.Discard
 	}
 
@@ -128,7 +135,7 @@ func cutFile(w io.Writer, path string, quiet bool) error {
 }
 
 // handlePaste pastes the most recent clipboard entry
-func handlePaste(w io.Writer, persist, quiet bool) error {
+func handlePaste(w io.Writer, opts Options) error {
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
@@ -144,11 +151,11 @@ func handlePaste(w io.Writer, persist, quiet bool) error {
 		return fmt.Errorf("source path no longer exists: %s", entry.CurrentPath)
 	}
 
-	return handlePasteAt(w, numEntries-1, persist, quiet)
+	return handlePasteAt(w, numEntries-1, opts)
 }
 
 // handlePasteAt pastes a specific clipboard entry by index
-func handlePasteAt(w io.Writer, index int, persist, quiet bool) error {
+func handlePasteAt(w io.Writer, index int, opts Options) error {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -168,16 +175,16 @@ func handlePasteAt(w io.Writer, index int, persist, quiet bool) error {
 		return fmt.Errorf("source path no longer exists: %s", entry.CurrentPath)
 	}
 
-	result, err := pasteEntry(entry, pwd, persist)
+	result, err := pasteEntry(entry, pwd, opts)
 	if err != nil {
 		return err
 	}
 
-	if quiet {
+	if opts.quiet {
 		w = io.Discard
 	}
 
-	if persist {
+	if opts.persist {
 		if err := updateEntryPath(index, result); err != nil {
 			return err
 		}
@@ -193,7 +200,7 @@ func handlePasteAt(w io.Writer, index int, persist, quiet bool) error {
 }
 
 // pasteEntry performs the actual paste operation (copy or move)
-func pasteEntry(entry Entry, destDir string, persist bool) (string, error) {
+func pasteEntry(entry Entry, destDir string, opts Options) (string, error) {
 	srcInfo, err := os.Lstat(entry.CurrentPath)
 	if err != nil {
 		return "", err
@@ -201,7 +208,7 @@ func pasteEntry(entry Entry, destDir string, persist bool) (string, error) {
 
 	destPath := filepath.Join(destDir, filepath.Base(entry.CurrentPath))
 
-	if persist {
+	if opts.persist {
 		if srcInfo.IsDir() {
 			err = copyDir(entry.CurrentPath, destPath)
 		} else if srcInfo.Mode()&os.ModeSymlink != 0 {
@@ -385,7 +392,7 @@ func renderPath(entry listEntry, width int) string {
 	}
 }
 
-func renderTable(w io.Writer, entries []listEntry, detailedFlag bool, maxPathWidth, maxSizeWidth, maxIndexWidth int) {
+func renderTable(w io.Writer, entries []listEntry, opts Options, maxPathWidth, maxSizeWidth, maxIndexWidth int) {
 
 	idxStyle := indexStyle(maxIndexWidth)
 
@@ -398,7 +405,7 @@ func renderTable(w io.Writer, entries []listEntry, detailedFlag bool, maxPathWid
 			continue
 		}
 
-		if detailedFlag {
+		if opts.detailed {
 
 			fmt.Fprintf(w, "%s %s %s %s %s %s\n", indexStr, pathStr,
 				detailsStyle.Render(fmt.Sprintf("%*s", maxSizeWidth, entry.sizeDisplay)),
@@ -424,7 +431,7 @@ type jsonEntry struct {
 	Error        string    `json:"error,omitempty"`
 }
 
-func renderJSON(w io.Writer, entries []listEntry, detailedFlag bool) error {
+func renderJSON(w io.Writer, entries []listEntry, opts Options) error {
 	jsonEntries := make([]jsonEntry, 0, len(entries))
 
 	for _, entry := range entries {
@@ -440,7 +447,7 @@ func renderJSON(w io.Writer, entries []listEntry, detailedFlag bool) error {
 			e.Symlink = entry.symlinkTarget
 		}
 
-		if detailedFlag {
+		if opts.detailed {
 			e.Size = entry.size
 			e.Permissions = entry.perms
 			e.LastModified = entry.modTime
@@ -460,7 +467,7 @@ func renderJSON(w io.Writer, entries []listEntry, detailedFlag bool) error {
 }
 
 // handleList displays all clipboard entries with proper column alignment
-func handleList(w io.Writer, detailedFlag, jsonFlag bool) error {
+func handleList(w io.Writer, opts Options) error {
 	// todo: use relative paths
 	clipboard, err := readClipboard()
 	if err != nil {
@@ -528,16 +535,16 @@ func handleList(w io.Writer, detailedFlag, jsonFlag bool) error {
 		}
 	}
 
-	if jsonFlag {
-		return renderJSON(w, entries, detailedFlag)
+	if opts.json {
+		return renderJSON(w, entries, opts)
 	}
 
-	renderTable(w, entries, detailedFlag, maxPathWidth, maxSizeWidth, maxIndexWidth)
+	renderTable(w, entries, opts, maxPathWidth, maxSizeWidth, maxIndexWidth)
 	return nil
 }
 
 // handleClear clears all clipboard entries
-func handleClear(w io.Writer, quiet bool) error {
+func handleClear(w io.Writer, opts Options) error {
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
@@ -550,7 +557,7 @@ func handleClear(w io.Writer, quiet bool) error {
 		return err
 	}
 
-	if quiet {
+	if opts.quiet {
 		w = io.Discard
 	}
 

--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -17,7 +17,7 @@ import (
 type Entry struct {
 	OriginalPath string    `json:"original_path"`
 	CurrentPath  string    `json:"current_path"`
-	Timestamp    time.Time `json:"timestamp"`
+	CutAt        time.Time `json:"timestamp"`
 }
 
 // Clipboard represents the collection of clipboard entries
@@ -110,7 +110,7 @@ func cutFile(w io.Writer, path string) error {
 	clipboard.Entries = append(clipboard.Entries, Entry{
 		OriginalPath: absPath,
 		CurrentPath:  absPath,
-		Timestamp:    time.Now(),
+		CutAt:        time.Now(),
 	})
 
 	err = writeClipboard(clipboard)
@@ -310,15 +310,30 @@ func removeFromClipboard(index int) error {
 	return writeClipboard(clipboard)
 }
 
+// should this just be nesting the clipboard entry?
+// is it better to build this at display time or at cut time?
 type displayEntry struct {
-	index     int
-	path      string // display path, including " -> target" for symlinks
-	size      string
-	perms     string
-	modTime   time.Time
-	isDir     bool
-	isLink    bool
-	isMissing bool
+	index         int
+	path          string // display path, including " -> target" for symlinks
+	barePath      string
+	symlinkTarget string
+	size          int64
+	sizeDisplay   string
+	perms         string
+	modTime       time.Time
+	cutTime       time.Time
+	isDir         bool
+	isLink        bool
+	isMissing     bool
+}
+
+type jsonEntry struct {
+	Path         string    `json:"path"`
+	Symlink      string    `json:"symlink,omitempty"`
+	Size         int64     `json:"size"`
+	Permissions  string    `json:"permissions"`
+	LastModified time.Time `json:"last_modified"`
+	CutAt        time.Time `json:"cut_at"`
 }
 
 var (
@@ -370,7 +385,9 @@ func renderPath(entry displayEntry, width int) string {
 }
 
 // handleList displays all clipboard entries with proper column alignment
-func handleList(w io.Writer, detailed bool) error {
+func handleList(w io.Writer, detailed, jsonFlag bool) error {
+	// todo: reverse the clipboard
+	// todo: use relative paths
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
@@ -385,6 +402,7 @@ func handleList(w io.Writer, detailed bool) error {
 	maxIndexWidth := len(strconv.Itoa(numEntries)) + 1
 
 	entries := make([]displayEntry, 0, numEntries)
+
 	maxPathWidth := 0
 	maxSizeWidth := 0
 
@@ -392,6 +410,7 @@ func handleList(w io.Writer, detailed bool) error {
 		var de displayEntry
 		de.index = i
 		de.path = entry.OriginalPath
+		de.cutTime = entry.CutAt
 
 		fileInfo, err := os.Lstat(entry.OriginalPath)
 		if err != nil {
@@ -403,7 +422,8 @@ func handleList(w io.Writer, detailed bool) error {
 			continue
 		}
 
-		de.size = FormatSize(fileInfo)
+		de.size = fileInfo.Size()
+		de.sizeDisplay = FormatSize(fileInfo.Size())
 		de.perms = fileInfo.Mode().String()
 		de.modTime = fileInfo.ModTime()
 		de.isDir = fileInfo.IsDir()
@@ -412,6 +432,8 @@ func handleList(w io.Writer, detailed bool) error {
 		if de.isLink {
 			if target, err := os.Readlink(entry.OriginalPath); err == nil {
 				de.path = fmt.Sprintf("%s -> %s", entry.OriginalPath, target)
+				de.barePath = entry.OriginalPath
+				de.symlinkTarget = target
 			} else {
 				de.path = fmt.Sprintf("%s -> (broken)", entry.OriginalPath)
 			}
@@ -423,12 +445,14 @@ func handleList(w io.Writer, detailed bool) error {
 			maxPathWidth = len(de.path)
 		}
 
-		if len(de.size) > maxSizeWidth {
-			maxSizeWidth = len(de.size)
+		if len(de.sizeDisplay) > maxSizeWidth {
+			maxSizeWidth = len(de.sizeDisplay)
 		}
 	}
 
 	idxStyle := indexStyle(maxIndexWidth)
+
+	jsonEntries := make([]jsonEntry, 0, numEntries)
 
 	for _, entry := range entries {
 		indexStr := idxStyle.Render(fmt.Sprintf("%d:", entry.index))
@@ -441,19 +465,77 @@ func handleList(w io.Writer, detailed bool) error {
 		}
 
 		if detailed {
-			fmt.Fprintf(w, "%s %s %s %s %s\n", indexStr, pathStr,
+			if jsonFlag {
+				var thisPath string
+				var symlink string
+				if entry.isLink {
+					thisPath = entry.barePath
+					symlink = entry.symlinkTarget
+				} else {
+					thisPath = entry.path
+				}
+				jsonEntries = append(jsonEntries, jsonEntry{
+					Path:         thisPath,
+					Symlink:      symlink,
+					Size:         entry.size,
+					Permissions:  entry.perms,
+					LastModified: entry.modTime,
+					CutAt:        entry.cutTime,
+				})
+				continue
+			}
+
+			fmt.Fprintf(w, "%s %s %s %s %s %s\n", indexStr, pathStr,
 				detailsStyle.Render(fmt.Sprintf("%*s", maxSizeWidth, entry.size)),
 				detailsStyle.Render(entry.perms),
 				detailsStyle.Render(entry.modTime.Format("2006-01-02 15:04:05")),
+				detailsStyle.Render(FormatCutAtTime(entry.cutTime)),
 			)
 			continue
 		}
 
-		fmt.Fprintf(w, "%s %s %s %s\n", indexStr, pathStr,
-			detailsStyle.Render(fmt.Sprintf("%*s", maxSizeWidth, entry.size)),
-			detailsStyle.Render(FormatLastModTime(entry.modTime)),
-		)
+		if jsonFlag {
+			var thisPath string
+			var symlink string
+			if entry.isLink {
+				thisPath = entry.barePath
+				symlink = entry.symlinkTarget
+			} else {
+				thisPath = entry.path
+			}
+			jsonEntries = append(jsonEntries, jsonEntry{Path: thisPath, Symlink: symlink})
+			continue
+		}
 
+		fmt.Fprintf(w, "%s %s\n", indexStr, pathStr)
+
+	}
+
+	if jsonFlag {
+		if detailed {
+
+			b, err := json.MarshalIndent(jsonEntries, "", " ")
+			if err != nil {
+				panic(err)
+				// todo: decide how to handle this
+			}
+			fmt.Fprintf(w, "%s\n", string(b))
+		} else {
+			type simple struct {
+				Path    string `json:"path"`
+				Symlink string `json:"symlink,omitempty"`
+			}
+			jsonPathEntries := make([]simple, 0, numEntries)
+			for _, entry := range jsonEntries {
+				jsonPathEntries = append(jsonPathEntries, simple{Path: entry.Path, Symlink: entry.Symlink})
+			}
+			b, err := json.MarshalIndent(jsonPathEntries, "", " ")
+			if err != nil {
+				panic(err)
+				// todo: decide how to handle this
+			}
+			fmt.Fprintf(w, "%s\n", string(b))
+		}
 	}
 
 	return nil

--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -310,12 +311,11 @@ func removeFromClipboard(index int) error {
 	return writeClipboard(clipboard)
 }
 
-// should this just be nesting the clipboard entry?
 // is it better to build this at display time or at cut time?
-type displayEntry struct {
+// should this just be nesting the clipboard Entry?
+type listEntry struct {
 	index         int
-	path          string // display path, including " -> target" for symlinks
-	barePath      string
+	basePath      string
 	symlinkTarget string
 	size          int64
 	sizeDisplay   string
@@ -325,15 +325,6 @@ type displayEntry struct {
 	isDir         bool
 	isLink        bool
 	isMissing     bool
-}
-
-type jsonEntry struct {
-	Path         string    `json:"path"`
-	Symlink      string    `json:"symlink,omitempty"`
-	Size         int64     `json:"size"`
-	Permissions  string    `json:"permissions"`
-	LastModified time.Time `json:"last_modified"`
-	CutAt        time.Time `json:"cut_at"`
 }
 
 var (
@@ -370,28 +361,106 @@ func indexStyle(width int) lipgloss.Style {
 		Align(lipgloss.Right)
 }
 
-func renderPath(entry displayEntry, width int) string {
-	padded := fmt.Sprintf("%-*s", width, entry.path)
+func renderPath(entry listEntry, width int) string {
+	padded := fmt.Sprintf("%-*s", width, entry.basePath)
 	switch {
 	case entry.isMissing:
 		return missingPathStyle.Render(padded)
 	case entry.isDir:
 		return dirStyle.Render(padded)
 	case entry.isLink:
+		path := fmt.Sprintf("%s -> %s", entry.basePath, entry.symlinkTarget)
+		padded := fmt.Sprintf("%-*s", width, path)
 		return symlinkStyle.Render(padded)
 	default:
 		return fileStyle.Render(padded)
 	}
 }
 
+func renderTable(w io.Writer, entries []listEntry, detailedFlag bool, maxPathWidth, maxSizeWidth, maxIndexWidth int) {
+
+	idxStyle := indexStyle(maxIndexWidth)
+
+	for _, entry := range entries {
+		indexStr := idxStyle.Render(fmt.Sprintf("%d:", entry.index))
+		pathStr := renderPath(entry, maxPathWidth)
+
+		if entry.isMissing {
+			fmt.Fprintf(w, "%s %s %s\n", indexStr, pathStr, detailsStyle.Render("(file not found)"))
+			continue
+		}
+
+		if detailedFlag {
+
+			fmt.Fprintf(w, "%s %s %s %s %s %s\n", indexStr, pathStr,
+				detailsStyle.Render(fmt.Sprintf("%*s", maxSizeWidth, entry.sizeDisplay)),
+				detailsStyle.Render(entry.perms),
+				detailsStyle.Render(entry.modTime.Format("2006-01-02 15:04:05")),
+				detailsStyle.Render(FormatCutAtTime(entry.cutTime)),
+			)
+			continue
+		}
+
+		fmt.Fprintf(w, "%s %s\n", indexStr, pathStr)
+
+	}
+}
+
+type jsonEntry struct {
+	Path         string    `json:"path"`
+	Symlink      string    `json:"symlink,omitempty"`
+	Size         int64     `json:"size,omitempty"`
+	Permissions  string    `json:"permissions,omitempty"`
+	LastModified time.Time `json:"last_modified,omitzero"`
+	CutAt        time.Time `json:"cut_at,omitzero"`
+	Error        string    `json:"error,omitempty"`
+}
+
+func renderJSON(w io.Writer, entries []listEntry, detailedFlag bool) error {
+	jsonEntries := make([]jsonEntry, 0, len(entries))
+
+	for _, entry := range entries {
+		e := jsonEntry{Path: entry.basePath}
+
+		if entry.isMissing {
+			e.Error = "file not found"
+			jsonEntries = append(jsonEntries, e)
+			continue
+		}
+
+		if entry.isLink {
+			e.Symlink = entry.symlinkTarget
+		}
+
+		if detailedFlag {
+			e.Size = entry.size
+			e.Permissions = entry.perms
+			e.LastModified = entry.modTime
+			e.CutAt = entry.cutTime
+		}
+		jsonEntries = append(jsonEntries, e)
+
+	}
+
+	b, err := json.MarshalIndent(jsonEntries, "", " ")
+	if err == nil {
+		fmt.Fprintf(w, "%s\n", string(b))
+	}
+
+	return err
+
+}
+
 // handleList displays all clipboard entries with proper column alignment
-func handleList(w io.Writer, detailed, jsonFlag bool) error {
+func handleList(w io.Writer, detailedFlag, jsonFlag bool) error {
 	// todo: reverse the clipboard
 	// todo: use relative paths
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
 	}
+
+	slices.Reverse(clipboard.Entries)
 
 	numEntries := len(clipboard.Entries)
 	if numEntries == 0 {
@@ -401,143 +470,62 @@ func handleList(w io.Writer, detailed, jsonFlag bool) error {
 
 	maxIndexWidth := len(strconv.Itoa(numEntries)) + 1
 
-	entries := make([]displayEntry, 0, numEntries)
+	entries := make([]listEntry, 0, numEntries)
 
 	maxPathWidth := 0
 	maxSizeWidth := 0
 
 	for i, entry := range clipboard.Entries {
-		var de displayEntry
-		de.index = i
-		de.path = entry.OriginalPath
-		de.cutTime = entry.CutAt
+		var e listEntry
+		e.index = i
+		e.basePath = entry.OriginalPath
+		e.cutTime = entry.CutAt
 
 		fileInfo, err := os.Lstat(entry.OriginalPath)
 		if err != nil {
-			de.isMissing = true
-			entries = append(entries, de)
-			if len(de.path) > maxPathWidth {
-				maxPathWidth = len(de.path)
+			e.isMissing = true
+			entries = append(entries, e)
+			if len(e.basePath) > maxPathWidth {
+				maxPathWidth = len(e.basePath)
 			}
 			continue
 		}
 
-		de.size = fileInfo.Size()
-		de.sizeDisplay = FormatSize(fileInfo.Size())
-		de.perms = fileInfo.Mode().String()
-		de.modTime = fileInfo.ModTime()
-		de.isDir = fileInfo.IsDir()
-		de.isLink = fileInfo.Mode()&os.ModeSymlink != 0
+		e.size = fileInfo.Size()
+		e.sizeDisplay = FormatSize(e.size)
+		e.perms = fileInfo.Mode().String()
+		e.modTime = fileInfo.ModTime()
+		e.isDir = fileInfo.IsDir()
+		e.isLink = fileInfo.Mode()&os.ModeSymlink != 0
+		displayPathWidth := len(e.basePath)
 
-		if de.isLink {
+		if e.isLink {
 			if target, err := os.Readlink(entry.OriginalPath); err == nil {
-				de.path = fmt.Sprintf("%s -> %s", entry.OriginalPath, target)
-				de.barePath = entry.OriginalPath
-				de.symlinkTarget = target
+				displayPathWidth = len(fmt.Sprintf("%s -> %s", e.basePath, target))
+				e.symlinkTarget = target
 			} else {
-				de.path = fmt.Sprintf("%s -> (broken)", entry.OriginalPath)
-			}
-		}
-
-		entries = append(entries, de)
-
-		if len(de.path) > maxPathWidth {
-			maxPathWidth = len(de.path)
-		}
-
-		if len(de.sizeDisplay) > maxSizeWidth {
-			maxSizeWidth = len(de.sizeDisplay)
-		}
-	}
-
-	idxStyle := indexStyle(maxIndexWidth)
-
-	jsonEntries := make([]jsonEntry, 0, numEntries)
-
-	for _, entry := range entries {
-		indexStr := idxStyle.Render(fmt.Sprintf("%d:", entry.index))
-		pathStr := renderPath(entry, maxPathWidth)
-
-		if entry.isMissing {
-			// todo: decide whether this level of info is fine
-			fmt.Fprintf(w, "%s %s %s\n", indexStr, pathStr, detailsStyle.Render("(file not found)"))
-			continue
-		}
-
-		if detailed {
-			if jsonFlag {
-				var thisPath string
-				var symlink string
-				if entry.isLink {
-					thisPath = entry.barePath
-					symlink = entry.symlinkTarget
-				} else {
-					thisPath = entry.path
-				}
-				jsonEntries = append(jsonEntries, jsonEntry{
-					Path:         thisPath,
-					Symlink:      symlink,
-					Size:         entry.size,
-					Permissions:  entry.perms,
-					LastModified: entry.modTime,
-					CutAt:        entry.cutTime,
-				})
-				continue
+				displayPathWidth = len(fmt.Sprintf("%s -> (broken)", e.basePath))
+				e.symlinkTarget = "(broken)"
 			}
 
-			fmt.Fprintf(w, "%s %s %s %s %s %s\n", indexStr, pathStr,
-				detailsStyle.Render(fmt.Sprintf("%*s", maxSizeWidth, entry.size)),
-				detailsStyle.Render(entry.perms),
-				detailsStyle.Render(entry.modTime.Format("2006-01-02 15:04:05")),
-				detailsStyle.Render(FormatCutAtTime(entry.cutTime)),
-			)
-			continue
 		}
 
-		if jsonFlag {
-			var thisPath string
-			var symlink string
-			if entry.isLink {
-				thisPath = entry.barePath
-				symlink = entry.symlinkTarget
-			} else {
-				thisPath = entry.path
-			}
-			jsonEntries = append(jsonEntries, jsonEntry{Path: thisPath, Symlink: symlink})
-			continue
+		entries = append(entries, e)
+
+		if displayPathWidth > maxPathWidth {
+			maxPathWidth = displayPathWidth
 		}
 
-		fmt.Fprintf(w, "%s %s\n", indexStr, pathStr)
-
+		if len(e.sizeDisplay) > maxSizeWidth {
+			maxSizeWidth = len(e.sizeDisplay)
+		}
 	}
 
 	if jsonFlag {
-		if detailed {
-
-			b, err := json.MarshalIndent(jsonEntries, "", " ")
-			if err != nil {
-				panic(err)
-				// todo: decide how to handle this
-			}
-			fmt.Fprintf(w, "%s\n", string(b))
-		} else {
-			type simple struct {
-				Path    string `json:"path"`
-				Symlink string `json:"symlink,omitempty"`
-			}
-			jsonPathEntries := make([]simple, 0, numEntries)
-			for _, entry := range jsonEntries {
-				jsonPathEntries = append(jsonPathEntries, simple{Path: entry.Path, Symlink: entry.Symlink})
-			}
-			b, err := json.MarshalIndent(jsonPathEntries, "", " ")
-			if err != nil {
-				panic(err)
-				// todo: decide how to handle this
-			}
-			fmt.Fprintf(w, "%s\n", string(b))
-		}
+		return renderJSON(w, entries, detailedFlag)
 	}
 
+	renderTable(w, entries, detailedFlag, maxPathWidth, maxSizeWidth, maxIndexWidth)
 	return nil
 }
 

--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -85,7 +85,7 @@ func writeClipboard(clipboard Clipboard) error {
 }
 
 // cutFile adds a file or directory to the clipboard
-func cutFile(w io.Writer, path string) error {
+func cutFile(w io.Writer, path string, quiet bool) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return err
@@ -119,12 +119,16 @@ func cutFile(w io.Writer, path string) error {
 		return err
 	}
 
+	if quiet {
+		w = io.Discard
+	}
+
 	fmt.Fprintf(w, "Cut: %s\n", absPath)
 	return nil
 }
 
 // handlePaste pastes the most recent clipboard entry
-func handlePaste(w io.Writer, persist bool) error {
+func handlePaste(w io.Writer, persist, quiet bool) error {
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
@@ -140,11 +144,11 @@ func handlePaste(w io.Writer, persist bool) error {
 		return fmt.Errorf("source path no longer exists: %s", entry.CurrentPath)
 	}
 
-	return handlePasteAt(w, numEntries-1, persist)
+	return handlePasteAt(w, numEntries-1, persist, quiet)
 }
 
 // handlePasteAt pastes a specific clipboard entry by index
-func handlePasteAt(w io.Writer, index int, persist bool) error {
+func handlePasteAt(w io.Writer, index int, persist, quiet bool) error {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -167,6 +171,10 @@ func handlePasteAt(w io.Writer, index int, persist bool) error {
 	result, err := pasteEntry(entry, pwd, persist)
 	if err != nil {
 		return err
+	}
+
+	if quiet {
+		w = io.Discard
 	}
 
 	if persist {
@@ -453,7 +461,6 @@ func renderJSON(w io.Writer, entries []listEntry, detailedFlag bool) error {
 
 // handleList displays all clipboard entries with proper column alignment
 func handleList(w io.Writer, detailedFlag, jsonFlag bool) error {
-	// todo: reverse the clipboard
 	// todo: use relative paths
 	clipboard, err := readClipboard()
 	if err != nil {
@@ -530,7 +537,7 @@ func handleList(w io.Writer, detailedFlag, jsonFlag bool) error {
 }
 
 // handleClear clears all clipboard entries
-func handleClear(w io.Writer) error {
+func handleClear(w io.Writer, quiet bool) error {
 	clipboard, err := readClipboard()
 	if err != nil {
 		return err
@@ -541,6 +548,10 @@ func handleClear(w io.Writer) error {
 	err = writeClipboard(clipboard)
 	if err != nil {
 		return err
+	}
+
+	if quiet {
+		w = io.Discard
 	}
 
 	fmt.Fprintln(w, "Clipboard cleared")

--- a/cmd/cx/clipboard_test.go
+++ b/cmd/cx/clipboard_test.go
@@ -385,7 +385,7 @@ func TestHandleList(t *testing.T) {
 	defer cleanup()
 
 	// Test empty clipboard
-	err := handleList(io.Discard, false)
+	err := handleList(io.Discard, false, false)
 	if err != nil {
 		t.Fatalf("handleList failed on empty clipboard: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestHandleList(t *testing.T) {
 	}
 
 	// Test list with entries
-	err = handleList(io.Discard, false)
+	err = handleList(io.Discard, false, false)
 	if err != nil {
 		t.Fatalf("handleList failed: %v", err)
 	}

--- a/cmd/cx/clipboard_test.go
+++ b/cmd/cx/clipboard_test.go
@@ -63,7 +63,7 @@ func TestCutFile(t *testing.T) {
 	testFile := filepath.Join(tempDir, "file1.txt")
 
 	// Test cutting a valid file
-	err := cutFile(io.Discard, testFile)
+	err := cutFile(io.Discard, testFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestCutNonexistentFile(t *testing.T) {
 
 	nonexistentFile := filepath.Join(tempDir, "nonexistent.txt")
 
-	err := cutFile(io.Discard, nonexistentFile)
+	err := cutFile(io.Discard, nonexistentFile, false)
 	if err == nil {
 		t.Fatal("Expected error when cutting nonexistent file, got nil")
 	}
@@ -105,7 +105,7 @@ func TestCutDirectory(t *testing.T) {
 
 	testDir := filepath.Join(tempDir, "config")
 
-	err := cutFile(io.Discard, testDir)
+	err := cutFile(io.Discard, testDir, false)
 	if err != nil {
 		t.Fatalf("cutFile failed for directory: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestMultipleCuts(t *testing.T) {
 
 	// Cut multiple files
 	for _, file := range files {
-		err := cutFile(io.Discard, file)
+		err := cutFile(io.Discard, file, false)
 		if err != nil {
 			t.Fatalf("cutFile failed for %s: %v", file, err)
 		}
@@ -176,7 +176,7 @@ func TestPasteMove(t *testing.T) {
 	}
 
 	// Cut the file
-	err = cutFile(io.Discard, sourceFile)
+	err = cutFile(io.Discard, sourceFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestPasteMove(t *testing.T) {
 	}
 
 	// Paste (move) the file
-	err = handlePaste(io.Discard, false) // persist = false means move
+	err = handlePaste(io.Discard, false, false) // persist = false means move
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestPasteCopy(t *testing.T) {
 	}
 
 	// Cut the file
-	err = cutFile(io.Discard, sourceFile)
+	err = cutFile(io.Discard, sourceFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestPasteCopy(t *testing.T) {
 	}
 
 	// Paste (copy) the file
-	err = handlePaste(io.Discard, true) // persist = true means copy
+	err = handlePaste(io.Discard, true, false) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestPasteDirectory(t *testing.T) {
 	}
 
 	// Cut the directory
-	err = cutFile(io.Discard, sourceDir)
+	err = cutFile(io.Discard, sourceDir, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestPasteDirectory(t *testing.T) {
 	}
 
 	// Paste (copy) the directory
-	err = handlePaste(io.Discard, true) // persist = true means copy
+	err = handlePaste(io.Discard, true, false) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestPasteEmptyClipboard(t *testing.T) {
 	defer cleanup()
 
 	// Try to paste from empty clipboard
-	err := handlePaste(io.Discard, false)
+	err := handlePaste(io.Discard, false, false)
 	if err == nil {
 		t.Fatal("Expected error when pasting from empty clipboard, got nil")
 	}
@@ -358,7 +358,7 @@ func TestPasteNonexistentFile(t *testing.T) {
 	sourceFile := filepath.Join(tempDir, "file1.txt")
 
 	// Cut the file
-	err := cutFile(io.Discard, sourceFile)
+	err := cutFile(io.Discard, sourceFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestPasteNonexistentFile(t *testing.T) {
 	}
 
 	// Try to paste - should fail
-	err = handlePaste(io.Discard, false)
+	err = handlePaste(io.Discard, false, false)
 	if err == nil {
 		t.Fatal("Expected error when pasting nonexistent file, got nil")
 	}
@@ -397,7 +397,7 @@ func TestHandleList(t *testing.T) {
 	}
 
 	for _, file := range files {
-		err := cutFile(io.Discard, file)
+		err := cutFile(io.Discard, file, false)
 		if err != nil {
 			t.Fatalf("cutFile failed: %v", err)
 		}
@@ -416,7 +416,7 @@ func TestHandleClear(t *testing.T) {
 
 	// Add a file to clipboard
 	sourceFile := filepath.Join(tempDir, "file1.txt")
-	err := cutFile(io.Discard, sourceFile)
+	err := cutFile(io.Discard, sourceFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestHandleClear(t *testing.T) {
 	}
 
 	// Clear clipboard
-	err = handleClear(io.Discard)
+	err = handleClear(io.Discard, false)
 	if err != nil {
 		t.Fatalf("handleClear failed: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestClipboardPersistence(t *testing.T) {
 	sourceFile := filepath.Join(tempDir, "file1.txt")
 
 	// Cut a file
-	err := cutFile(io.Discard, sourceFile)
+	err := cutFile(io.Discard, sourceFile, false)
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}

--- a/cmd/cx/clipboard_test.go
+++ b/cmd/cx/clipboard_test.go
@@ -63,7 +63,7 @@ func TestCutFile(t *testing.T) {
 	testFile := filepath.Join(tempDir, "file1.txt")
 
 	// Test cutting a valid file
-	err := cutFile(io.Discard, testFile, false)
+	err := cutFile(io.Discard, testFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestCutNonexistentFile(t *testing.T) {
 
 	nonexistentFile := filepath.Join(tempDir, "nonexistent.txt")
 
-	err := cutFile(io.Discard, nonexistentFile, false)
+	err := cutFile(io.Discard, nonexistentFile, Options{})
 	if err == nil {
 		t.Fatal("Expected error when cutting nonexistent file, got nil")
 	}
@@ -105,7 +105,7 @@ func TestCutDirectory(t *testing.T) {
 
 	testDir := filepath.Join(tempDir, "config")
 
-	err := cutFile(io.Discard, testDir, false)
+	err := cutFile(io.Discard, testDir, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed for directory: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestMultipleCuts(t *testing.T) {
 
 	// Cut multiple files
 	for _, file := range files {
-		err := cutFile(io.Discard, file, false)
+		err := cutFile(io.Discard, file, Options{})
 		if err != nil {
 			t.Fatalf("cutFile failed for %s: %v", file, err)
 		}
@@ -176,7 +176,7 @@ func TestPasteMove(t *testing.T) {
 	}
 
 	// Cut the file
-	err = cutFile(io.Discard, sourceFile, false)
+	err = cutFile(io.Discard, sourceFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestPasteMove(t *testing.T) {
 	}
 
 	// Paste (move) the file
-	err = handlePaste(io.Discard, false, false) // persist = false means move
+	err = handlePaste(io.Discard, Options{}) // persist = false means move
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestPasteCopy(t *testing.T) {
 	}
 
 	// Cut the file
-	err = cutFile(io.Discard, sourceFile, false)
+	err = cutFile(io.Discard, sourceFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestPasteCopy(t *testing.T) {
 	}
 
 	// Paste (copy) the file
-	err = handlePaste(io.Discard, true, false) // persist = true means copy
+	err = handlePaste(io.Discard, Options{persist: true}) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestPasteDirectory(t *testing.T) {
 	}
 
 	// Cut the directory
-	err = cutFile(io.Discard, sourceDir, false)
+	err = cutFile(io.Discard, sourceDir, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestPasteDirectory(t *testing.T) {
 	}
 
 	// Paste (copy) the directory
-	err = handlePaste(io.Discard, true, false) // persist = true means copy
+	err = handlePaste(io.Discard, Options{persist: true}) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestPasteEmptyClipboard(t *testing.T) {
 	defer cleanup()
 
 	// Try to paste from empty clipboard
-	err := handlePaste(io.Discard, false, false)
+	err := handlePaste(io.Discard, Options{})
 	if err == nil {
 		t.Fatal("Expected error when pasting from empty clipboard, got nil")
 	}
@@ -358,7 +358,7 @@ func TestPasteNonexistentFile(t *testing.T) {
 	sourceFile := filepath.Join(tempDir, "file1.txt")
 
 	// Cut the file
-	err := cutFile(io.Discard, sourceFile, false)
+	err := cutFile(io.Discard, sourceFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestPasteNonexistentFile(t *testing.T) {
 	}
 
 	// Try to paste - should fail
-	err = handlePaste(io.Discard, false, false)
+	err = handlePaste(io.Discard, Options{})
 	if err == nil {
 		t.Fatal("Expected error when pasting nonexistent file, got nil")
 	}
@@ -385,7 +385,7 @@ func TestHandleList(t *testing.T) {
 	defer cleanup()
 
 	// Test empty clipboard
-	err := handleList(io.Discard, false, false)
+	err := handleList(io.Discard, Options{})
 	if err != nil {
 		t.Fatalf("handleList failed on empty clipboard: %v", err)
 	}
@@ -397,14 +397,14 @@ func TestHandleList(t *testing.T) {
 	}
 
 	for _, file := range files {
-		err := cutFile(io.Discard, file, false)
+		err := cutFile(io.Discard, file, Options{})
 		if err != nil {
 			t.Fatalf("cutFile failed: %v", err)
 		}
 	}
 
 	// Test list with entries
-	err = handleList(io.Discard, false, false)
+	err = handleList(io.Discard, Options{})
 	if err != nil {
 		t.Fatalf("handleList failed: %v", err)
 	}
@@ -416,7 +416,7 @@ func TestHandleClear(t *testing.T) {
 
 	// Add a file to clipboard
 	sourceFile := filepath.Join(tempDir, "file1.txt")
-	err := cutFile(io.Discard, sourceFile, false)
+	err := cutFile(io.Discard, sourceFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestHandleClear(t *testing.T) {
 	}
 
 	// Clear clipboard
-	err = handleClear(io.Discard, false)
+	err = handleClear(io.Discard, Options{})
 	if err != nil {
 		t.Fatalf("handleClear failed: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestClipboardPersistence(t *testing.T) {
 	sourceFile := filepath.Join(tempDir, "file1.txt")
 
 	// Cut a file
-	err := cutFile(io.Discard, sourceFile, false)
+	err := cutFile(io.Discard, sourceFile, Options{})
 	if err != nil {
 		t.Fatalf("cutFile failed: %v", err)
 	}

--- a/cmd/cx/formatters.go
+++ b/cmd/cx/formatters.go
@@ -2,21 +2,20 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/dustin/go-humanize"
 )
 
-// FormatLastModTime returns a formatted string containing the human-readable
+// FormatCutAtTime returns a formatted string containing the human-readable
 // last modified time of the provided os.FileInfo.
-func FormatLastModTime(modTime time.Time) string {
+func FormatCutAtTime(modTime time.Time) string {
 	fileLastModified := humanize.Time(modTime)
 	return fmt.Sprintf("(%s)", fileLastModified)
 }
 
 // FormatLastModTime returns a formatted string containing the human-readable
 // size of the provided os.FileInfo.
-func FormatSize(fileInfo os.FileInfo) string {
-	return humanize.Bytes(uint64(fileInfo.Size()))
+func FormatSize(size int64) string {
+	return humanize.Bytes(uint64(size))
 }

--- a/cmd/cx/formatters.go
+++ b/cmd/cx/formatters.go
@@ -9,8 +9,8 @@ import (
 
 // FormatCutAtTime returns a formatted string containing the human-readable
 // last modified time of the provided os.FileInfo.
-func FormatCutAtTime(modTime time.Time) string {
-	fileLastModified := humanize.Time(modTime)
+func FormatCutAtTime(t time.Time) string {
+	fileLastModified := humanize.Time(t)
 	return fmt.Sprintf("(%s)", fileLastModified)
 }
 

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -19,14 +19,18 @@ func init() {
 	defaultClipboardPath := filepath.Join(homeDir, ".cx_clipboard.json")
 
 	rootCmd.PersistentFlags().StringVar(&clipboardPath, "clipboard", defaultClipboardPath, "path to the clipboard file")
+	rootCmd.Flags().BoolP("quiet", "q", false, "suppress all output, except errors")
 
 	rootCmd.AddCommand(pasteCmd)
+	pasteCmd.Flags().BoolP("persist", "p", false, "keep file at original path after paste")
+	pasteCmd.Flags().BoolP("quiet", "q", false, "suppress all output, except errors")
 
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolP("detailed", "d", false, "show detailed file information")
 	listCmd.Flags().Bool("json", false, "output clipboard as JSON")
 
 	rootCmd.AddCommand(clearCmd)
+	clearCmd.Flags().BoolP("quiet", "q", false, "suppress all output, except errors")
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -36,7 +40,8 @@ var rootCmd = &cobra.Command{
 	Long:  `cx allows you to cut and paste files and directories from the command line.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return cutFile(cmd.OutOrStdout(), args[0])
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		return cutFile(cmd.OutOrStdout(), args[0], quiet)
 	},
 }
 
@@ -45,7 +50,9 @@ var pasteCmd = &cobra.Command{
 	Use:   "paste",
 	Short: "Paste the most recent clipboard entry",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return handlePaste(cmd.OutOrStdout(), false)
+		persist, _ := cmd.Flags().GetBool("persist")
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		return handlePaste(cmd.OutOrStdout(), persist, quiet)
 	},
 }
 
@@ -66,7 +73,8 @@ var clearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Clear clipboard contents",
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return handleClear(cmd.OutOrStdout())
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		return handleClear(cmd.OutOrStdout(), quiet)
 	},
 }
 

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		return cutFile(cmd.OutOrStdout(), args[0], quiet)
+		return cutFile(cmd.OutOrStdout(), args[0], Options{quiet: quiet})
 	},
 }
 
@@ -52,7 +52,7 @@ var pasteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		persist, _ := cmd.Flags().GetBool("persist")
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		return handlePaste(cmd.OutOrStdout(), persist, quiet)
+		return handlePaste(cmd.OutOrStdout(), Options{persist: persist, quiet: quiet})
 	},
 }
 
@@ -64,7 +64,7 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		detailed, _ := cmd.Flags().GetBool("detailed")
 		json, _ := cmd.Flags().GetBool("json")
-		return handleList(cmd.OutOrStdout(), detailed, json)
+		return handleList(cmd.OutOrStdout(), Options{detailed: detailed, json: json})
 	},
 }
 
@@ -74,7 +74,7 @@ var clearCmd = &cobra.Command{
 	Short: "Clear clipboard contents",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		return handleClear(cmd.OutOrStdout(), quiet)
+		return handleClear(cmd.OutOrStdout(), Options{quiet: quiet})
 	},
 }
 

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -24,6 +24,7 @@ func init() {
 
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolP("detailed", "d", false, "show detailed file information")
+	listCmd.Flags().Bool("json", false, "output clipboard as JSON")
 
 	rootCmd.AddCommand(clearCmd)
 }
@@ -55,7 +56,8 @@ var listCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		detailed, _ := cmd.Flags().GetBool("detailed")
-		return handleList(cmd.OutOrStdout(), detailed)
+		json, _ := cmd.Flags().GetBool("json")
+		return handleList(cmd.OutOrStdout(), detailed, json)
 	},
 }
 


### PR DESCRIPTION
## Summary
  - `--json` outputs the clipboard as a JSON array
  - `--quiet` suppresses informational output from effectful commands
  - Refactored flags into an options struct for cleaner flag handling