### PR TITLE
Paste specific clipboard entries by index

### DIFF
--- a/cmd/cx/clipboard.go
+++ b/cmd/cx/clipboard.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"time"
 
@@ -115,11 +114,12 @@ func cutFile(w io.Writer, path string, opts Options) error {
 		return err
 	}
 
-	clipboard.Entries = append(clipboard.Entries, Entry{
+	// prepend entry since clipboard is a stack
+	clipboard.Entries = append([]Entry{Entry{
 		OriginalPath: absPath,
 		CurrentPath:  absPath,
 		CutAt:        time.Now(),
-	})
+	}}, clipboard.Entries...)
 
 	err = writeClipboard(clipboard)
 	if err != nil {
@@ -132,26 +132,6 @@ func cutFile(w io.Writer, path string, opts Options) error {
 
 	fmt.Fprintf(w, "Cut: %s\n", absPath)
 	return nil
-}
-
-// handlePaste pastes the most recent clipboard entry
-func handlePaste(w io.Writer, opts Options) error {
-	clipboard, err := readClipboard()
-	if err != nil {
-		return err
-	}
-
-	numEntries := len(clipboard.Entries)
-	if numEntries == 0 {
-		return fmt.Errorf("clipboard is empty")
-	}
-
-	entry := clipboard.Entries[numEntries-1]
-	if _, err := os.Lstat(entry.CurrentPath); err != nil {
-		return fmt.Errorf("source path no longer exists: %s", entry.CurrentPath)
-	}
-
-	return handlePasteAt(w, numEntries-1, opts)
 }
 
 // handlePasteAt pastes a specific clipboard entry by index
@@ -471,8 +451,6 @@ func handleList(w io.Writer, opts Options) error {
 	if err != nil {
 		return err
 	}
-
-	slices.Reverse(clipboard.Entries)
 
 	numEntries := len(clipboard.Entries)
 	if numEntries == 0 {

--- a/cmd/cx/clipboard_test.go
+++ b/cmd/cx/clipboard_test.go
@@ -191,7 +191,7 @@ func TestPasteMove(t *testing.T) {
 	}
 
 	// Paste (move) the file
-	err = handlePaste(io.Discard, Options{}) // persist = false means move
+	err = handlePasteAt(io.Discard, 0, Options{}) // persist = false means move
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestPasteCopy(t *testing.T) {
 	}
 
 	// Paste (copy) the file
-	err = handlePaste(io.Discard, Options{persist: true}) // persist = true means copy
+	err = handlePasteAt(io.Discard, 0, Options{persist: true}) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestPasteDirectory(t *testing.T) {
 	}
 
 	// Paste (copy) the directory
-	err = handlePaste(io.Discard, Options{persist: true}) // persist = true means copy
+	err = handlePasteAt(io.Discard, 0, Options{persist: true}) // persist = true means copy
 	if err != nil {
 		t.Fatalf("handlePaste failed: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestPasteEmptyClipboard(t *testing.T) {
 	defer cleanup()
 
 	// Try to paste from empty clipboard
-	err := handlePaste(io.Discard, Options{})
+	err := handlePasteAt(io.Discard, 0, Options{})
 	if err == nil {
 		t.Fatal("Expected error when pasting from empty clipboard, got nil")
 	}
@@ -370,7 +370,7 @@ func TestPasteNonexistentFile(t *testing.T) {
 	}
 
 	// Try to paste - should fail
-	err = handlePaste(io.Discard, Options{})
+	err = handlePasteAt(io.Discard, 0, Options{})
 	if err == nil {
 		t.Fatal("Expected error when pasting nonexistent file, got nil")
 	}

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -47,12 +49,23 @@ var rootCmd = &cobra.Command{
 
 // pasteCmd represents the paste command
 var pasteCmd = &cobra.Command{
-	Use:   "paste",
+	Use:   "paste [index]",
 	Short: "Paste the most recent clipboard entry",
-	RunE: func(cmd *cobra.Command, _ []string) error {
+	Args:  cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		persist, _ := cmd.Flags().GetBool("persist")
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		return handlePaste(cmd.OutOrStdout(), Options{persist: persist, quiet: quiet})
+
+		index := 0
+		if len(args) == 1 {
+			var err error
+			index, err = strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid index: %s", args[0])
+			}
+		}
+		return handlePasteAt(cmd.OutOrStdout(), index, Options{persist: persist, quiet: quiet})
+
 	},
 }
 


### PR DESCRIPTION
## Summary
 - Add optional `[index]` argument to `cx paste` to paste a specific entry (e.g. `cx paste 1`)
 - Defaults to index 0 (most recent) when no argument is given
 - Clipboard is stored as a stack
 - Remove handlePaste in favour of calling handlePasteAt directly with a default index of 0

## Test plan
 - `cx paste` still pastes the most recent entry
 - `cx paste 2` pastes the entry shown at index 2 in cx list
 - `cx paste foo` returns a clear `invalid index` error
 - `cx paste 99` on a small clipboard returns `invalid clipboard index` error